### PR TITLE
rm link to newsletter archive

### DIFF
--- a/content/about-us/newsletter.md
+++ b/content/about-us/newsletter.md
@@ -9,8 +9,8 @@ aliases:
 
 {{< grid cols=12 gap=4 >}}
   {{< slot span=8 >}}
-    See our [newsletter archive](#archive)
-    {{< mc_newsletter_form >}}
+Should we have any general text about the newsletter here?
+  {{< mc_newsletter_form >}}
   {{</ slot >}}
 
   {{< slot span=4 >}}


### PR DESCRIPTION
Remove link to newsletter archive as we have a side-by-side layout.  Leave question about what text we may want to have there.  