### PR TITLE
Link to current handbook section on lesson maintenance

### DIFF
--- a/content/community/maintainers.md
+++ b/content/community/maintainers.md
@@ -5,7 +5,7 @@ aliaes:
 - /maintainers/
 ---
 
-Maintainers are responsible for the day-to-day upkeep of our lessons - making sure they stay accurate, up-to-date, functional, and cohesive. You can learn more about the Maintainer role, and how to become a Maintainer in our [Maintainer Handbook](#).
+Maintainers are responsible for the day-to-day upkeep of our lessons - making sure they stay accurate, up-to-date, functional, and cohesive. You can learn more about the Maintainer role, and how to become a Maintainer in our [Maintainer Handbook](https://docs.carpentries.org/topic_folders/maintainers/index.html).
 
 This page lists our current Maintainers. Previous Maintainers are listed on our [Maintainer Alumni](/community/maintainer-alumni) page. 
 


### PR DESCRIPTION
At the moment, the link at https://carpentries.org/community/maintainers/# to the Maintainer Handbook goes nowhere. This changes that to point to the lesson maintenance section of the current handbook. I can come back and replace that with the new link when the handbook relaunch has happened.