### PR TITLE
Update URL for I want to... host a workshop

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,7 +5,7 @@ blocks:
 - layout: select-cta
   options:
     - copy: Host a workshop
-      url: /host/host-workshop/
+      url: /workshops/host-workshop/
     - copy: Become a member organisation
       url: /support/membership/
     - copy: Become a volunteer


### PR DESCRIPTION
Fixes the link to "host a workshop" in the "I want to..." menu