### PR TITLE
Update CLDT heading on Pricing page

### DIFF
--- a/content/support/pricing.md
+++ b/content/support/pricing.md
@@ -36,7 +36,7 @@ Recruit your own trainees and The Carpentries Instructor Training will provide t
 |Low Income          |$375                      |
 {{< /table >}}
 
-## Collaborative Lesson Development Pricing
+## Collaborative Lesson Development Training Pricing
 
 Collaborative Lesson Development Training gives your community members the skills they need to design and implement effective, accessible curriculum together. Our two-part, 24-hour training teaches best practices in curriculum design and collaborative development of an open source lesson website. For more information about Collaborative Lesson Development, visit our [Collaborative Lesson Development page](/lesson-development/).
 


### PR DESCRIPTION
I missed this during content review, sorry. This adds the word "Training" into the CLDT heading on the Pricing page, making it more consistent with the heading for Instructor Training further up the page.