### PR TITLE
Formatting of emails address list in subcommunity registry

### DIFF
--- a/data/subcommunity.yml
+++ b/data/subcommunity.yml
@@ -98,7 +98,8 @@ subcommunities:
     - teaching:
     - other: 
   contact:
-    - email: admin-au@carpentries.org
+    - email: 
+      - "admin-au@carpentries.org"
     - slack:
     - mailing_list: https://carpentries.topicbox.com/groups/local-aunz
     - contact_form:
@@ -428,7 +429,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: facilitator@datascience.wisc.edu
+    - email: 
+      - "facilitator@datascience.wisc.edu"
     - slack: "data-science-hubgroup workspace, #uw_carpentries"
     - mailing_list:  https://groups.google.com/a/g-groups.wisc.edu/g/carpentries
     - contact_form:
@@ -486,7 +488,8 @@ subcommunities:
     - teaching:
     - other: 
   contact:
-    - email: carpentries@si.edu
+    - email: 
+      - "carpentries@si.edu"
     - slack: "Smithsonian workspace, #carpentries-alumni"
     - mailing_list: 
     - contact_form:
@@ -598,7 +601,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: dreamlab@library.ucsb.edu
+    - email: 
+      - "dreamlab@library.ucsb.edu"
     - slack: ucsbcarpentry workspace
     - mailing_list: https://groups.google.com/a/library.ucsb.edu/g/carpentry/about
     - contact_form:
@@ -653,7 +657,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: maintainers-hpc@lists.carpentries.org
+    - email: 
+      - "maintainers-hpc@lists.carpentries.org"
     - slack:  "Carpentries workspace, #hpc-carpentry"
     - mailing_list: https://carpentries.topicbox.com/groups/discuss-hpc
     - contact_form: https://www.hpc-carpentry.org/contact/
@@ -708,7 +713,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: kozo.nishida@gmail.com
+    - email: 
+      - "kozo.nishida@gmail.com"
     - slack: "Carpentries workspace, #local-japan"
     - mailing_list:
     - contact_form:
@@ -763,7 +769,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: contact-us@carpentry.uio.no
+    - email: 
+      - "contact-us@carpentry.uio.no"
     - slack: "Carpentries workspace, #oslo-community"
     - mailing_list: 
     - contact_form:
@@ -874,7 +881,8 @@ subcommunities:
     - teaching:
     - other: 
   contact:
-    - email: muellerr@zbmed.de
+    - email: 
+      - "muellerr@zbmed.de"
     - slack: "Carpentries workspace, #local-dach"
     - mailing_list: https://carpentries.topicbox.com/groups/local-dach
     - contact_form:
@@ -929,7 +937,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: ndporter@vt.edu
+    - email: 
+      - "ndporter@vt.edu"
     - slack:
     - mailing_list: 
     - contact_form: 
@@ -984,7 +993,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: nselem84@gmail.com
+    - email: 
+      - "nselem84@gmail.com"
     - slack: "Carpentries workspace"
     - mailing_list: carpentries-mexico@googlegroups.com
     - contact_form: 
@@ -1039,7 +1049,8 @@ subcommunities:
     - teaching: true
     - other: 
   contact:
-    - email: nrrome@berklee.edu
+    - email: 
+      - "nrrome@berklee.edu"
     - slack: "Carpentries workspace, #local-us-northeast"
     - mailing_list: 
     - contact_form: 
@@ -1094,7 +1105,8 @@ subcommunities:
     - teaching: 
     - other: 
   contact:
-    - email: obk1@st-andrews.ac.uk
+    - email: 
+      - "obk1@st-andrews.ac.uk"
     - slack: "Carpentries workspace, #local-ukrainian"
     - mailing_list: 
     - contact_form: 

--- a/layouts/shortcodes/subcommunity.html
+++ b/layouts/shortcodes/subcommunity.html
@@ -52,8 +52,14 @@
 <!-- list group contacts  -->
 <div>
     <b>Connect: </b>
+
     {{ range .contact }}
-    {{ if .email }}<a href="mailto:{{ .email }}">Email</a> / {{ end }}
+
+    {{ if .email }} Email: 
+        {{ range $index, $email :=  .email }}
+            {{ if $index }} / {{ end }}<a href="mailto:{{ $email }}">{{ $email }}</a>{{ end }} /
+    {{ end }}
+
     {{ if .slack }}Slack: {{ .slack }} / {{ end }}
     {{ if .mailing_list }}<a href="{{ .mailing_list }}">Mailing list</a> / {{ end }}
     {{ if .contact_form }}<a href="{{ .contact_form }}">Contact form</a> / {{ end }}


### PR DESCRIPTION
Based off comments in #344 this PR transforms the email address yaml data to a list and then displays each email address directly in the subcommunity's listing.