### PR TITLE
condition to show search on 404 page

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -95,3 +95,9 @@ handbook_url: https://docs.carpentries.org
 # Other forms
 #############################################
 accommodation_request: https://carpentries.typeform.com/to/B2OSYaD0
+
+# Technical parameters
+#############################################
+
+# To include "search" option from 404 page
+include404search: true 


### PR DESCRIPTION
Dependent on https://github.com/carpentries/carpentries-hugo-theme/pull/66

This adds the parameter to show the "search" suggestion on the 404 page.  This parameter will not be added to the lesson program sites, so it will not show on those sites. 