### PR TITLE
Revert "Take down help wanted table" 

### DIFF
--- a/content/lessons/help_wanted.md
+++ b/content/lessons/help_wanted.md
@@ -5,7 +5,11 @@ aliases:
 - /help-wanted-issues/
 ---
 
-This page is under development. The "Help Wanted" table will be restored by April 4, 2025.
+The table below lists all lessons labelled "Help wanted" and/or "good first issue" on many of our repositories and lesson repositories in [The Carpentries Incubator]({{< param incubator_link >}}). We hope it will help you find opportunities to contribute to Carpentries lessons and projects.
+
+If you are a Maintainer and would like to include issues from your lesson repository in this table, please read the [Information for Lesson Maintainers](#information-for-maintainers) at the end of the page.
+
+{{< help_wanted >}}
 
 ## Information for Maintainers
 


### PR DESCRIPTION
This reverts commit fb7e5ac735d7859a5e748e7fe27253b06a90cbe6. That was made because we had hit the Airtable API limit for March. Restored as it is April 1.