### PR TITLE
Help wanted error check

### DIFF
--- a/layouts/shortcodes/help_wanted.html
+++ b/layouts/shortcodes/help_wanted.html
@@ -1,17 +1,22 @@
 {{ $help_wanted := dict }}
-
+{{ $data_available := false }}
 {{ $url := "https://feeds.carpentries.org/help_wanted_issues.json" }}
 
 {{ with resources.GetRemote $url }}
-  {{ with .Err }}
-    {{ errorf "%s" . }}
+  {{ if .Err }}
+    {{ printf "Unable to get remote resource %q" $url | warnf }}
   {{ else }}
+    {{ $data_available = true }}
     {{ $help_wanted = . | transform.Unmarshal }}
   {{ end }}
 {{ else }}
   {{ errorf "Unable to get remote resource %q" $url }}
 {{ end }}
 
+{{ if not $data_available }}
+<strong>Help wanted data is not currently available.</strong>
+
+{{ else }}
 <table>
     <thead>
         <tr>
@@ -56,3 +61,5 @@
 {{ end }}
 
 </table>
+
+{{ end }}

--- a/layouts/shortcodes/help_wanted.html
+++ b/layouts/shortcodes/help_wanted.html
@@ -14,7 +14,9 @@
 {{ end }}
 
 {{ if not $data_available }}
-<strong>Help wanted data is not currently available.</strong>
+<strong>Our help wanted list is not currently available.  Please contact
+the Carpentries Curriculum Team at curriculum@carpentries.org if you have any questions.</strong>
+
 
 {{ else }}
 <table>


### PR DESCRIPTION
The help wanted table is failing because we hit our Airtable API limit.  I'm [in the process of using GH to get the help wanted feed](https://github.com/carpentries/feeds.carpentries.org/pull/95) instead of having to maintain the Airtable.  

This PR adds an additional check so that if the feed is unavailable, we have placeholder text instead of having the build fail.