### PR TITLE
Searchable tables 

### DIFF
--- a/content/lesson-development/community-lessons.md
+++ b/content/lesson-development/community-lessons.md
@@ -3,6 +3,7 @@ title: Community Lessons
 layout: single
 aliases:
 - /community-lessons/
+datatable: true 
 ---
 
 The Carpentries community is committed to a collaborative and open process for lesson development and to sharing teaching materials. We provide two avenues for community members to share lesson materials - [The Carpentries Incubator]({{< param incubator_link >}}) and [The Carpentries Lab]({{< param lab_link >}}).

--- a/layouts/partials/datatable.html
+++ b/layouts/partials/datatable.html
@@ -1,6 +1,6 @@
 <script>
     $(document).ready(function() {
-      $('#community_lessons').DataTable({
+      $('.sortable_table').DataTable({
         // Optional config
         paging: true,
         searching: true,

--- a/layouts/partials/datatable.html
+++ b/layouts/partials/datatable.html
@@ -1,0 +1,13 @@
+<script>
+    $(document).ready(function() {
+      $('#community_lessons').DataTable({
+        // Optional config
+        paging: true,
+        searching: true,
+        ordering: true,
+        language: {
+      lengthMenu: "Show _MENU_",  // Customize the "Show X entries" text
+    }
+      });
+    });
+  </script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,6 +9,12 @@
 <link href="https://fonts.googleapis.com/css2?family=Mulish:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
 <script defer src="https://cdn.jsdelivr.net/npm/@glidejs/glide@3.5.x"></script>
 <script src="https://kit.fontawesome.com/3a6fac633d.js" crossorigin="anonymous"></script>
+<!-- DataTables CSS -->
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+
+<!-- jQuery and DataTables JS -->
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
 <script>
 var _paq = window._paq = window._paq || [];
 _paq.push(["setDoNotTrack", true]);
@@ -31,3 +37,8 @@ _paq.push(['enableLinkTracking']);
 {{ partialCached "head/js.html" . }}
 {{ template "_internal/opengraph.html" . }}
 {{ template "_internal/schema.html" . }}
+
+{{ if .Params.datatable }}
+{{ partial "datatable.html" . }}
+{{ end }}
+

--- a/layouts/shortcodes/community_lessons.html
+++ b/layouts/shortcodes/community_lessons.html
@@ -1,5 +1,7 @@
 {{ $community_lessons := dict }}
 
+
+
 {{ $url := "https://feeds.carpentries.org/community_lessons.json" }}
 
 {{ with resources.GetRemote $url }}
@@ -13,7 +15,7 @@
 {{ end }}
 
 
-<table>
+<table id="community_lessons">
 <thead>
     <tr>
     <th>Lesson Title</th>

--- a/layouts/shortcodes/community_lessons.html
+++ b/layouts/shortcodes/community_lessons.html
@@ -15,7 +15,7 @@
 {{ end }}
 
 
-<table id="community_lessons">
+<table class="sortable_table">
 <thead>
     <tr>
     <th>Lesson Title</th>


### PR DESCRIPTION
Sets up searchable tables using https://datatables.net/.
Addresses https://github.com/carpentries/carpentries-hugo-theme/issues/53.  

Right now this only applies to the community lessons table.  Once we fix the issues with the help wanted feed, we can apply this to that table as well.