### PR TITLE
add corporate pricing tables

### DIFF
--- a/content/support/pricing.md
+++ b/content/support/pricing.md
@@ -7,7 +7,9 @@ cascade:
 
 ## Overview
 
-All fees are dependent on the purchasing organisation's geographic location, according to the [World Bank's gross national income categorisation](https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html). All fees listed are in USD and represent costs for not-for-profit organisations and academic institutions. Pricing for for-profit organisations is four times the price listed for non-profit organisations.
+All fees are dependent on the purchasing organisation's geographic location, according to the [World Bank's gross national income categorisation](https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html). 
+
+**All fees listed are in USD.** Pricing for for-profit organisations is four times the price listed for not-for-profit organisations and academic institutions.
 
 ## Workshop Pricing
 

--- a/content/support/pricing.md
+++ b/content/support/pricing.md
@@ -33,7 +33,7 @@ Recruit your own trainees and The Carpentries Instructor Training will provide t
 |High Income         |$1,500                                 |$6,000                                |
 |Upper-Middle Income |$1,125                                 |$4,500                                |
 |Lower-Middle Income |$750                                   |$3,000                                |
-|Low Income          |$375                                   |$1,000                                |
+|Low Income          |$375                                   |$1,500                                |
 {{< /table >}}
 
 ## Collaborative Lesson Development Training Pricing

--- a/content/support/pricing.md
+++ b/content/support/pricing.md
@@ -15,12 +15,12 @@ Our Centrally-Organised Workshops bring hands-on computational and data skill wo
 
 
 {{< table >}}
-|                    |Workshop Fee (USD)|
-|------------------- |---------------   |
-|High Income         |$3,000            |
-|Upper-Middle Income |$2,250            |
-|Lower-Middle Income |$1,500            |
-|Low Income          |$750              |
+|                    |Workshop Fee (Non-profit)|Workshop Fee (Corporate)|
+|------------------- |------------------------ |------------------------ |
+|High Income         |$3,000                   |$12,000                  |
+|Upper-Middle Income |$2,250                   |$9,000                   |
+|Lower-Middle Income |$1,500                   |$6,000                   |
+|Low Income          |$750                     |$3,000                     |
 {{< /table >}}
 
 ## Instructor Training Pricing
@@ -28,12 +28,12 @@ Our Centrally-Organised Workshops bring hands-on computational and data skill wo
 Recruit your own trainees and The Carpentries Instructor Training will provide them the skills to teach effective workshops. Through our 16-hour, hands-on training, they will learn the basics of educational psychology and evidence-based teaching practices. For more information about Instructor Training, visit our [Instructor Training page](/instructor-training/).
 
 {{< table >}}
-|                    | Instructor Training Seat |
-|--------------------|--------------------------|
-|High Income         |$1,500                    |
-|Upper-Middle Income |$1,125                    |
-|Lower-Middle Income |$750                      |
-|Low Income          |$375                      |
+|                    | Instructor Training Seat (Non-profit) | Instructor Training Seat (Corporate) |
+|--------------------|---------------------------------------|--------------------------------------|
+|High Income         |$1,500                                 |$6,000                                |
+|Upper-Middle Income |$1,125                                 |$4,500                                |
+|Lower-Middle Income |$750                                   |$3,000                                |
+|Low Income          |$375                                   |$1,000                                |
 {{< /table >}}
 
 ## Collaborative Lesson Development Training Pricing
@@ -41,20 +41,21 @@ Recruit your own trainees and The Carpentries Instructor Training will provide t
 Collaborative Lesson Development Training gives your community members the skills they need to design and implement effective, accessible curriculum together. Our two-part, 24-hour training teaches best practices in curriculum design and collaborative development of an open source lesson website. For more information about Collaborative Lesson Development, visit our [Collaborative Lesson Development page](/lesson-development/).
 
 {{< table >}}
-|                    | Base fee (2 people) | Each additional person |
-|--------------------|---------------------|------------------------| 
-|High Income         |$5,000               | $1000                  |
-|Upper-Middle Income |$3,750               | $750                   |
-|Lower-Middle Income |$2,500               | $500                   |
-|Low Income          |$1,250               | $250                   |
+|                    | Base fee: 2 people (Non-profit) | Each additional person (Non-profit) |Base fee: 2 people (Corporate) | Each additional person (Corporate) |
+|--------------------|-----------|--------------|---------------|--------------------| 
+|High Income         |$5,000     | $1000        |$20,000        |$4,000              |
+|Upper-Middle Income |$3,750     | $750         |$15,000        |$3,000              | 
+|Lower-Middle Income |$2,500     | $500         |$10,000        |$2,000              |
+|Low Income          |$1,250     | $250         |$5,000         |$1,000              | 
 {{< /table >}}
 
 ## Membership Pricing
 
 Memberships include a bundle of Workshops and Instructor Training seats for organisations seeking to provide computational and data training to their community. Members can add-on additional Workshops, Instructor Training seats, and Collaborative Lesson Development Training seats to their Membership package at a 40% discount to the prices shown above. For more information about Membership, visit our [Membership page](/support/membership/).
 
-{{< table >}}
+### Non-profit pricing
 
+{{< table >}}
 |                                 | Bronze | Silver | Gold    | Platinum | Titanium |
 |------------------------         |--------|--------|---------| ---------| -------- |
 |**Centrally-Organised workshops**| 2      | 2      | 1       | 0        |   0      |
@@ -63,6 +64,19 @@ Memberships include a bundle of Workshops and Instructor Training seats for orga
 |Upper-Middle Income              | $2,700 | $6,075 | $12,150 | $10,125  |   $3,570 |
 |Lower-Middle Income              | $1,800 | $4,050 | $8,150  | $6,750   |   $2,500 |
 |Low Income                       | $900   | $2,025 | $4,050  | $3,375   |   $1,250 |
+{{< /table >}}
+
+### Corporate pricing
+
+{{< table >}}
+|                                 | Bronze   | Silver  | Gold    | Platinum | Titanium  |
+|------------------------         |----------|---------|---------| ---------| --------- |
+|**Centrally-Organised workshops**| 2        | 2       | 1       | 0        |   0       |
+|**Instructor Training seats**    | 0        | 5       | 14      | 15       |   0       |
+|High Income                      | $14,400  | $32,400 | $64,800 | $54,000  |   $20,000 |
+|Upper-Middle Income              | $10,800  | $24,300 | $48,600 | $40,500  |   $14,280 |
+|Lower-Middle Income              | $7,200   | $16,200 | $32,600 | $27,000  |   $10,000 |
+|Low Income                       | $3,600   | $8,100  | $16,200 | $13,500  |   $5,000  |
 {{< /table >}}
 
 ## Contact Us


### PR DESCRIPTION
Addresses question raised in #482.

An example of what it would look like if we added corporate pricing to the pricing page.  
For workshops, IT seats, and CLDT seats, this adds columns to the existing tables.  For membership, since that is a large table, it  adds another table.