### PR TITLE
update workshop requirements info

### DIFF
--- a/content/workshops/host-workshop.md
+++ b/content/workshops/host-workshop.md
@@ -17,15 +17,17 @@ A [Self-Organised workshop]({{< param handbook_url >}}/handbooks/instructors.htm
 
 If you are interested in hosting a Centrally-Organised workshop, you can learn more on this page. If you are interested in hosting a Self-Organised workshop, [you can learn more about organising one in our handbook]({{< param handbook_url >}}/handbooks/instructors.html#step-by-step-guides). 
 
-## Curriculum Requirements for Centrally-Organised Workshops 
+## Curriculum Requirements for Standard Carpentries Workshops 
 
-Centrally-Organised workshops must teach a lesson program’s core curriculum and can not be mixed with components from another lesson program’s curricula. Below, you will find the workshop requirements for each lesson program:
+All standard workshops must teach a lesson program’s core curriculum and can not be mixed with components from another lesson program’s curricula. Below, you will find the workshop requirements for each lesson program:
 
 * A [Library Carpentry]({{< param lc-website >}}) workshop should include any three lessons from the Library Carpentry curriculum  
 
 * A [Software Carpentry]({{< param swc-website >}}) workshop should include The Unix Shell, Version Control with Git, and a programming language (R or Python)  
 
 * A [Data Carpentry]({{< param dc-website >}}) workshop will vary based on its specific curriculum. It should generally include a lesson on one programming language (either R or Python) where applicable, as well as all other lessons outlined in the curriculum. *Data Carpentry (Genomics) workshops come with an additional fee for the use of Amazon Web Services (AWS) instances provided by The Carpentries. Please visit our [terms of agreement]({{< param handbook_url >}}/resources/workshops/genomics_policy.html) to learn more about the process of scheduling a Genomics workshop.*
+
+Only Self-Organised workshops offer flexibility to customize lessons, as long as all content is based on Carpentries materials. For more information, visit the [Instructors Handbook]{{< param handbook_url >}}/handbooks/instructors.html#self-organised).
 
 [Curricula overview](/lessons/curriculum-summary)
 {.button}


### PR DESCRIPTION
Following a [WIT meeting in June](https://docs.google.com/document/d/1jboeEjqK5aSLI-iCZTSP5AxtfOnb7LCA4loLA480BuA/edit?tab=t.0#bookmark=id.7aq5mrp2f3li) (private link) in June, this PR clarifies information about what makes a standard workshop.
