### PR TITLE
fix criteria for trainer feeds

### DIFF
--- a/content/community/instructor-trainer-alumni.md
+++ b/content/community/instructor-trainer-alumni.md
@@ -9,4 +9,4 @@ aliases:
 
 We like to acknowledge all of our community members and their continued support. Our Instructor Trainer Alumni are people who have played an active role in the Instructor Trainer community but are not currently active. 
 
-{{< persons feed="https://feeds.carpentries.org/all_trainers.json" where="active_status,Inactive Trainer" >}}
+{{< persons feed="https://feeds.carpentries.org/all_trainers.json" where="active_status,Inactive" >}}

--- a/content/community/instructor-trainers.md
+++ b/content/community/instructor-trainers.md
@@ -10,4 +10,4 @@ The Instructor Trainer community is a group of experienced Instructors, local ch
 
 Instructor Trainers may temporarily or permanently step away from this role. To continue to acknowledge their contributions to The Carpentries, we list them as [Trainer Alumni](/community/instructor-trainer-alumni/).
 
-{{< persons feed="https://feeds.carpentries.org/all_trainers.json" where="active_status,Active Trainer" >}}
+{{< persons feed="https://feeds.carpentries.org/all_trainers.json" where="active_status,Active" >}}


### PR DESCRIPTION
Trainers/Alumni feeds were not working because criteria changed from "Active {role-name}" to generic "Active" (and likewise for Inactive).