### PR TITLE
replaced dead link with DOI

### DIFF
--- a/content/posts/2014/01/best-practices-has-been-published.html
+++ b/content/posts/2014/01/best-practices-has-been-published.html
@@ -11,7 +11,7 @@ tags: ["Announcements", "Software Carpentry"]
 <p><b>This post originally appeared on the <a href="https://software-carpentry.org/">Software Carpentry website.</a></b></p>
 <p>
   I'm very pleased to announce that our paper
-  <a href="http://www.plosbiology.org/article/info%3Adoi%2F10.1371%2Fjournal.pbio.1001745">Best Practices for Scientific Computing</a>
+  <a href="https://doi.org/10.1371/journal.pbio.1001745">Best Practices for Scientific Computing</a>
   has been published in <a href="http://www.plosbiology.org/"><cite>PLOS Biology</cite></a>.
   It presents 24 specific things scientists can do to get more done in less time with less pain:
 </p>


### PR DESCRIPTION
I replaced a dead link to a journal with the article's DOI, https://doi.org/10.1371/journal.pbio.1001745